### PR TITLE
CHG: copyright 연도 변경

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -75,7 +75,7 @@ authors:
 #  email:            your-id@your-email.com
 
 copyright:
-  year:             2017
+  year:             2018
   name:             8PERCENT
 
 # Google-analytics


### PR DESCRIPTION
블로그 footer의 연도가 2017년으로 되어 있어 2018년으로 수정합니다.
